### PR TITLE
Use uuid instead of username for comment author comparison

### DIFF
--- a/src/main/scala/ch/mibex/bitbucket/sonar/client/BitbucketClient.scala
+++ b/src/main/scala/ch/mibex/bitbucket/sonar/client/BitbucketClient.scala
@@ -1,11 +1,10 @@
 package ch.mibex.bitbucket.sonar.client
 
-import java.net.{HttpURLConnection, InetSocketAddress, URL}
+import java.net.{HttpURLConnection, InetSocketAddress, Proxy, URL}
 import javax.ws.rs.core.MediaType
 
-import ch.mibex.bitbucket.sonar.{SonarBBPlugin, SonarBBPluginConfig}
 import ch.mibex.bitbucket.sonar.utils.{JsonUtils, LogUtils}
-import java.net.Proxy
+import ch.mibex.bitbucket.sonar.{SonarBBPlugin, SonarBBPluginConfig}
 import com.sun.jersey.api.client.config.{ClientConfig, DefaultClientConfig}
 import com.sun.jersey.api.client.filter.LoggingFilter
 import com.sun.jersey.api.client.{Client, ClientResponse, UniformInterfaceException}
@@ -257,12 +256,21 @@ class BitbucketClient(config: SonarBBPluginConfig) extends BatchComponent {
   }
 
   private def getLoggedInUserUUID(): String = {
-    val response = client.resource(s"https://bitbucket.org/api/2.0/user")
-      .accept(MediaType.APPLICATION_JSON)
-      .get(classOf[String])
+    if (!config.isEnabled) {
+      return null
+    }
 
-    val user = JsonUtils.mapFromJson(response)
-    user("uuid").asInstanceOf[String]
+    try {
+      val response = client.resource(s"https://bitbucket.org/api/2.0/user")
+        .accept(MediaType.APPLICATION_JSON)
+        .get(classOf[String])
+
+      val user = JsonUtils.mapFromJson(response)
+      user("uuid").asInstanceOf[String]
+    } catch {
+      case e: UniformInterfaceException =>
+        throw new IllegalStateException(s"${SonarBBPlugin.PluginLogPrefix} Couldn't fetch logged in user uuid, got status: ${e.getResponse.getStatus}")
+    }
   }
 
 }


### PR DESCRIPTION
Stores the uuid of the logged in user / team and uses it for comparison with the author uuid on the comments.

Changed the 1.0 api calls for fetching the comments to 2.0 because the 1.0 do not contain the uuid, also re-used the already existing code for pagination.

If using oauth, in addition to the pull request permissions you will need "Account Read" permission.

Tested with both users and teams and multiple pages of comments.