### PR TITLE
Change the Bitbucket API URL prefix

### DIFF
--- a/src/main/scala/ch/mibex/bitbucket/sonar/client/BitbucketClient.scala
+++ b/src/main/scala/ch/mibex/bitbucket/sonar/client/BitbucketClient.scala
@@ -89,7 +89,7 @@ class BitbucketClient(config: SonarBBPluginConfig) {
   }
 
   private def createResource(apiVersion: String) =
-    client.resource(s"https://bitbucket.org/api/$apiVersion/repositories/${config.accountName()}/${config.repoSlug()}")
+    client.resource(s"https://api.bitbucket.org/$apiVersion/repositories/${config.accountName()}/${config.repoSlug()}")
 
   private def mapToPullRequest(pullRequest: Map[String, Any]): PullRequest = {
     val source = pullRequest("source").asInstanceOf[Map[String, Any]]
@@ -326,7 +326,7 @@ class BitbucketClient(config: SonarBBPluginConfig) {
   private def getLoggedInUserUUID: String = {
     try {
       val response = client
-        .resource(s"https://bitbucket.org/api/2.0/user")
+        .resource(s"https://api.bitbucket.org/2.0/user")
         .accept(MediaType.APPLICATION_JSON)
         .get(classOf[String])
       val user = JsonUtils.mapFromJson(response)


### PR DESCRIPTION
Change the Bitbucket API URL prefix from https://bitbucket.org/api to https://api.bitbucket.org/ to follow the [Bitbucket API reference](https://developer.atlassian.com/bitbucket/api/2/reference/meta/uri-uuid#uri-structure).

I found that the Bitbucket API returned 401 (UNAUTHORIZED) for this request:

```
Jul 01, 2017 9:58:41 PM com.sun.jersey.api.client.filter.LoggingFilter log
INFO: 4 * Client out-bound request
4 > GET https://bitbucket.org/!api/2.0/repositories/healarcon/sonar-bitbucket-plugin-test/diff/healarcon/sonar-bitbucket-plugin-test:2149ba45a456%0D4cd06df422ae?context=0
4 > Authorization: Basic <my-app-password>

Jul 01, 2017 9:58:41 PM com.sun.jersey.api.client.filter.LoggingFilter log
INFO: 4 * Client in-bound response
4 < 401
4 < Server: nginx
4 < WWW-Authenticate: Basic realm="Bitbucket.org HTTP"
4 < Connection: keep-alive
4 < X-Static-Version: dce5f507b47a
4 < X-Version: dce5f507b47a
4 < Date: Sat, 01 Jul 2017 21:58:41 GMT
4 < X-Frame-Options: SAMEORIGIN
4 < Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
4 < X-Render-Time: 0.258337020874
4 < ETag: "d41d8cd98f00b204e9800998ecf8427e"
4 < X-Served-By: app-107
4 < Vary: Accept-Language, Cookie
4 < Content-Length: 0
4 < Content-Language: en
4 < X-Request-Count: 577
4 < Content-Type: text/html; charset=utf-8
4 < 
```
In [this issue](https://bitbucket.org/site/master/issues/13909/api-20-diff-endpoint-returns-401-error) it was suggested to change the URL prefix. I changed it and it worked. After that the comments where correctly added to a pull request.

