### PR TITLE
Support Git directory which are outside current directory

### DIFF
--- a/src/main/scala/ch/mibex/bitbucket/sonar/GitBaseDirResolver.scala
+++ b/src/main/scala/ch/mibex/bitbucket/sonar/GitBaseDirResolver.scala
@@ -6,6 +6,7 @@ import org.sonar.api.batch.fs.InputFile
 import org.sonar.api.batch.postjob.issue.PostJobIssue
 import org.sonar.api.batch.{BatchSide, InstantiationStrategy}
 import org.sonar.api.scan.filesystem.PathResolver
+import org.sonar.api.utils.log.Loggers
 
 import scala.annotation.tailrec
 
@@ -14,14 +15,15 @@ import scala.annotation.tailrec
 // the git root (.git folder)
 @BatchSide
 @InstantiationStrategy(InstantiationStrategy.PER_BATCH)
-class GitBaseDirResolver {
+class GitBaseDirResolver (pluginConfig: SonarBBPluginConfig) {
   private var gitBaseDir: File = _
 
   def init(startDir: File, gitDirName: String = ".git"): Unit = {
     gitBaseDir = findRepositoryBaseDir(Option(startDir), gitDirName).getOrElse(
+      findRepositoryBaseDir(Option(new File(pluginConfig.gitBaseDir())), gitDirName).getOrElse(
       throw new IllegalArgumentException(
         s"${SonarBBPlugin.PluginLogPrefix} Unable to locate Git directory in ${startDir.getAbsolutePath}"
-      )
+      ))
     )
   }
 

--- a/src/main/scala/ch/mibex/bitbucket/sonar/SonarBBPlugin.scala
+++ b/src/main/scala/ch/mibex/bitbucket/sonar/SonarBBPlugin.scala
@@ -24,6 +24,7 @@ object SonarBBPlugin {
   final val BitbucketApproveUnapprove = "sonar.bitbucket.approvalFeatureEnabled"
   final val BitbucketBuildStatus = "sonar.bitbucket.buildStatusEnabled"
   final val SonarUnapprovalSeverityLevel = "sonar.bitbucket.maxSeverityApprovalLevel"
+  final val BitbucketGitBaseDir = "sonar.bitbucket.gitBaseDir"
 }
 
 
@@ -124,6 +125,13 @@ object SonarBBPlugin {
       defaultValue = "true",
       description = "If enabled, the plug-in will update the build status of the pull request depending on the " +
         "Sonar analysis result. The analysis and also the build is failed if there are any critical or blocker issues.",
+      global = true
+    ),
+    new Property(
+      key = SonarBBPlugin.BitbucketGitBaseDir,
+      name = "Base Git Directory",
+      defaultValue = ".",
+      description = "Use if Git directory is not same as current dir",
       global = true
     )
   )

--- a/src/main/scala/ch/mibex/bitbucket/sonar/SonarBBPluginConfig.scala
+++ b/src/main/scala/ch/mibex/bitbucket/sonar/SonarBBPluginConfig.scala
@@ -32,6 +32,8 @@ class SonarBBPluginConfig(settings: Settings, server: Server) {
 
   def sonarApprovalSeverityLevel(): String = settings.getString(SonarBBPlugin.SonarUnapprovalSeverityLevel)
 
+  def gitBaseDir(): String = settings.getString(SonarBBPlugin.BitbucketGitBaseDir)
+
   def branchName(): String = {
     var branchName = settings.getString(SonarBBPlugin.BitbucketBranchName)
     Option(branchName) foreach { _ =>

--- a/src/test/scala/ch/mibex/bitbucket/sonar/review/GitBaseDirResolverSpec.scala
+++ b/src/test/scala/ch/mibex/bitbucket/sonar/review/GitBaseDirResolverSpec.scala
@@ -3,7 +3,7 @@ package ch.mibex.bitbucket.sonar.review
 import java.io.File
 import java.nio.file.Path
 
-import ch.mibex.bitbucket.sonar.GitBaseDirResolver
+import ch.mibex.bitbucket.sonar.{GitBaseDirResolver, SonarBBPluginConfig}
 import org.junit.runner.RunWith
 import org.sonar.api.batch.fs.InputFile
 import org.sonar.api.batch.postjob.issue.PostJobIssue
@@ -19,7 +19,7 @@ class GitBaseDirResolverSpec extends Specification with Mockito {
   "getRepositoryRelativePath" should {
 
     "resolve Git relative path of given file" in {
-      val resolver = new GitBaseDirResolver
+      val resolver = new GitBaseDirResolver(mock[SonarBBPluginConfig])
       val baseDir = getClass.getResource("/gitrepo/multimod/src")
       resolver.init(new File(baseDir.getPath), "git")
 


### PR DESCRIPTION
This will help scenarios where sonar scanning is trigger in a directory which is not version controlled. This is specially true for SAP Hybris project.