### PR TITLE
Fix #110 Skip deleted comments

### DIFF
--- a/src/main/scala/ch/mibex/bitbucket/sonar/client/BitbucketClient.scala
+++ b/src/main/scala/ch/mibex/bitbucket/sonar/client/BitbucketClient.scala
@@ -144,10 +144,13 @@ class BitbucketClient(config: SonarBBPluginConfig) {
       Option(comment("user").asInstanceOf[Map[String, Any]])
         .getOrElse(Map("uuid" -> ""))("uuid").asInstanceOf[String] equals uuid
 
+    def isDeleted(comment: Map[String, Any]): Boolean = 
+	  Option(comment("deleted").asInstanceOf[Boolean]).getOrElse(false)
+
     def fetchPullRequestCommentsPage(start: Int): (Option[Int], Seq[PullRequestComment]) = {
       fetchPage(s"/pullrequests/${pullRequest.id}/comments", f =
         response =>
-          for (comment <- response("values").asInstanceOf[Seq[Map[String, Any]]] if isFromUs(comment))
+          for (comment <- response("values").asInstanceOf[Seq[Map[String, Any]]] if isFromUs(comment) && !isDeleted(comment))
             yield {
               val commentId = comment("id").asInstanceOf[Int]
               val content = comment("content").asInstanceOf[Map[String, Any]]("raw").asInstanceOf[String]


### PR DESCRIPTION
This PR skip all comments in the PR posted by the plugin comments marked as deleted. This allow new comment on same code line and same issue without get the 404 when you try to update a deleted comment